### PR TITLE
Temporary file cleanup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,22 +79,15 @@ fn show_post<F: Fn(Client) -> ()>(client: Client, post: &Post, pager: &str, on_f
             panic!("couldn't write to: {}", why);
         }
         Ok(_) => {
-            match tmpfile.path().to_str() {
-                Some(pth) => {
-                    let mut edit = Command::new(pager);
-                    edit.arg(pth);
-                    let status = edit.status().unwrap_or_else(|e| {
-                        panic!("Failed to open view: {}", e);
-                    });
-                    if !status.success() {
-                        panic!("View failed!");
-                    }
-                    on_finish(client);
-                }
-                None => {
-                    panic!("Failed to get temporary file path.");
-                }
+            let mut edit = Command::new(pager);
+            edit.arg(tmpfile.path());
+            let status = edit.status().unwrap_or_else(|e| {
+                panic!("Failed to open view: {}", e);
+            });
+            if !status.success() {
+                panic!("View failed!");
             }
+            on_finish(client);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,9 +73,8 @@ fn show_choose(items: Vec<(&str, bool)>) -> usize {
 }
 
 fn show_post<F: Fn(Client) -> ()>(client: Client, post: &Post, pager: &str, on_finish: F) {
-    let tmpfile: tempfile::NamedTempFile = tempfile::NamedTempFile::new().unwrap();
-    let mut file: File = OpenOptions::new().write(true).open(tmpfile.path()).unwrap();
-    match file.write_all(post.body.as_bytes()) {
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    match tmpfile.write_all(post.body.as_bytes()) {
         Err(why) => {
             panic!("couldn't write to: {}", why);
         }


### PR DESCRIPTION
Hi,

I maintain the tempfile library and occasionally go though dependent crates to make sure it's meeting the needs of its users. While doing so, I noticed that you were re-opening the tempfile to get a `File` object. FYI, you don't need to do that; `NamedTempFile` dereferences to a `File` object.

Also, I noticed you were converting a `&Path` to a `&str. As this is unnecessary, I removed this conversion.
